### PR TITLE
🎨 Palette: Improve accessibility of sidebar toggle button

### DIFF
--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -190,6 +190,9 @@ export default function Home() {
       <button 
         onClick={() => setIsExpanded(!isExpanded)} 
         className="absolute -right-3 top-6 bg-white border border-gray-200 rounded-full p-1 text-gray-500 hover:text-amber-700 hover:shadow-md transition-all z-50 hidden sm:block"
+        aria-label={isExpanded ? "Collapse sidebar" : "Expand sidebar"}
+        aria-expanded={isExpanded}
+        title={isExpanded ? "Collapse sidebar" : "Expand sidebar"}
       >
         {isExpanded ? <AiOutlineMenuFold size={20} /> : <AiOutlineMenuUnfold size={20} />}
       </button>


### PR DESCRIPTION
💡 What: Added `aria-label`, `aria-expanded` and `title` attributes to the sidebar toggle button.
🎯 Why: The collapse/expand button in the sidebar only contained an icon, which provided no context for screen readers and no hover text for sighted users.
♿ Accessibility: Improved screen reader support with `aria-label` and `aria-expanded` reflecting the current state, and added a tooltip via `title`.

---
*PR created automatically by Jules for task [3354592610310749929](https://jules.google.com/task/3354592610310749929) started by @AntonioCardenas*