### PR TITLE
⚡ Bolt: Move ApolloClient initialization out of App component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-24 - ApolloClient Re-initialization
+**Learning:** Initializing `ApolloClient` inside the main `App` component creates a new instance on every render, destroying the `InMemoryCache` and causing redundant network requests.
+**Action:** Always initialize `ApolloClient` outside of the React component tree to ensure the cache persists and performs efficiently.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,17 +15,15 @@ import '../src/styles/app.scss';
 
 import DynamicHeader from './components/DynamicHeader/DynamicHeader';
 
-const clientOracle = () =>
-  new ApolloClient({
-    link: new HttpLink({
-      uri: 'https://api.thegraph.com/subgraphs/name/jdestephen/affogato-sg',
-    }),
-    cache: new InMemoryCache(),
-  });
+const apolloClient = new ApolloClient({
+  link: new HttpLink({
+    uri: 'https://api.thegraph.com/subgraphs/name/jdestephen/affogato-sg',
+  }),
+  cache: new InMemoryCache(),
+});
 
 const App = () => {
   const contracts = useContracts();
-  const apolloClient = clientOracle();
 
   return (
     <>


### PR DESCRIPTION
💡 What: Moved the ApolloClient and InMemoryCache initialization outside of the App component.

🎯 Why: The `ApolloClient` instance was being recreated on every single render of the `App` component by the `clientOracle()` function. This caused the `InMemoryCache` to be destroyed continuously, defeating the purpose of caching and forcing unnecessary network requests on subsequent renders.

📊 Impact: Reduces redundant network requests significantly and improves overall application performance by keeping a stable instance of the apollo client alive across re-renders.

🔬 Measurement: Ensure network traffic is no longer spammed with identical graphql requests when you navigate inside the application and the application does not have multiple renders caused by data refetching.

---
*PR created automatically by Jules for task [6754484751672937077](https://jules.google.com/task/6754484751672937077) started by @AntonioCardenas*