### PR TITLE
🎨 Palette: Add ARIA labels and focus rings to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-09 - Missing Accessible Labels and Keyboard Focus on Icon-Only Buttons
+**Learning:** Found a recurring pattern in the codebase where icon-only buttons (like the sidebar collapse button or language switchers) lack both `aria-label`s for screen readers and visible focus states for keyboard navigation (`focus-visible`). This indicates a potential accessibility gap in the design system components used across the app, especially for interactive elements without text.
+**Action:** When reviewing or updating UI components, explicitly check for and add `aria-label` (and `aria-expanded` for toggles) along with `focus-visible:ring-2` to ensure they are accessible to both screen readers and keyboard users.

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -188,8 +188,10 @@ export default function Home() {
   return (
     <div className={`min-h-screen bg-base-100 transition-all duration-300 relative border-r border-gray-100 ${isExpanded ? 'w-64' : 'w-20'}`}>
       <button 
+        aria-label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
+        aria-expanded={isExpanded}
         onClick={() => setIsExpanded(!isExpanded)} 
-        className="absolute -right-3 top-6 bg-white border border-gray-200 rounded-full p-1 text-gray-500 hover:text-amber-700 hover:shadow-md transition-all z-50 hidden sm:block"
+        className="absolute -right-3 top-6 bg-white border border-gray-200 rounded-full p-1 text-gray-500 hover:text-amber-700 hover:shadow-md transition-all z-50 hidden sm:block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
       >
         {isExpanded ? <AiOutlineMenuFold size={20} /> : <AiOutlineMenuUnfold size={20} />}
       </button>

--- a/src/components/common/LangChooser.tsx
+++ b/src/components/common/LangChooser.tsx
@@ -39,25 +39,29 @@ const LangChooser = () => {
   const LangBar = () => (
     <div className="fixed bottom-4 right-4 z-50 flex items-center bg-white/80 backdrop-blur-md shadow-xl rounded-full p-1 border border-white/40 gap-1">
       <button 
-        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${currentLang === 'es' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`} 
+        aria-label="Change language to Español"
+        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${currentLang === 'es' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`}
         onClick={() => changeLanguage("es")}
       >
         <ES title="Español" className="w-6 rounded-sm shadow-sm" />
       </button>
       <button 
-        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${currentLang === 'en' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`} 
+        aria-label="Change language to English"
+        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${currentLang === 'en' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`}
         onClick={() => changeLanguage("en")}
       >
         <US title="English" className="w-6 rounded-sm shadow-sm" />
       </button>
       <button 
-        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${currentLang === 'de' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`} 
+        aria-label="Change language to Deutsch"
+        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${currentLang === 'de' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`}
         onClick={() => changeLanguage("de")}
       >
         <DE title="Deutsch" className="w-6 rounded-sm shadow-sm" />
       </button>
       <button 
-        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${currentLang === 'fr' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`} 
+        aria-label="Change language to Français"
+        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${currentLang === 'fr' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`}
         onClick={() => changeLanguage("fr")}
       >
         <FR title="Français" className="w-6 rounded-sm shadow-sm" />


### PR DESCRIPTION
💡 What: Added `aria-label`s and `focus-visible:ring-2` to the icon-only language switcher buttons and the sidebar collapse toggle. Also added `aria-expanded` to the sidebar toggle.
🎯 Why: To improve screen reader accessibility and provide visual feedback for keyboard navigation users.
♿ Accessibility: 
- Screen readers can now announce the purpose of language change buttons.
- Screen readers announce the collapse/expand state of the sidebar.
- Keyboard users can clearly see which interactive element currently has focus.

---
*PR created automatically by Jules for task [5261875670104725488](https://jules.google.com/task/5261875670104725488) started by @AntonioCardenas*