### PR TITLE
⚡ Bolt: Initialize ApolloClient outside component tree

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-25 - [Initialize ApolloClient Outside React Tree]
+**Learning:** Initializing an ApolloClient instance inside a React component (even at the root like App.tsx) causes the client and its InMemoryCache to be destroyed and re-instantiated on every re-render, negating all caching benefits and potentially causing severe performance degradation.
+**Action:** Always instantiate ApolloClient outside of the React component tree (e.g., at the module level) to ensure the cache persists across renders.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,17 +15,17 @@ import '../src/styles/app.scss';
 
 import DynamicHeader from './components/DynamicHeader/DynamicHeader';
 
-const clientOracle = () =>
-  new ApolloClient({
-    link: new HttpLink({
-      uri: 'https://api.thegraph.com/subgraphs/name/jdestephen/affogato-sg',
-    }),
-    cache: new InMemoryCache(),
-  });
+// ⚡ Bolt: Initialize ApolloClient outside of the React component tree
+// This prevents the client (and its cache) from being destroyed and recreated on every render.
+const apolloClient = new ApolloClient({
+  link: new HttpLink({
+    uri: 'https://api.thegraph.com/subgraphs/name/jdestephen/affogato-sg',
+  }),
+  cache: new InMemoryCache(),
+});
 
 const App = () => {
   const contracts = useContracts();
-  const apolloClient = clientOracle();
 
   return (
     <>


### PR DESCRIPTION
💡 What: Moved the ApolloClient initialization outside of the React `App` component.
🎯 Why: Instantiating ApolloClient inside the component tree causes it (and its cache) to be destroyed and recreated on every re-render. This destroys the benefits of GraphQL caching and causes unnecessary performance overhead.
📊 Impact: Prevents continuous cache invalidation and unnecessary network requests. Reduces re-renders and improves responsiveness for data-dependent components.
🔬 Measurement: Verify by checking network tab (GraphQL requests should now hit cache instead of refetching constantly on UI updates) and by observing improved rendering speed in the app.

---
*PR created automatically by Jules for task [8784474449069433178](https://jules.google.com/task/8784474449069433178) started by @AntonioCardenas*