### PR TITLE
⚡ Bolt: Optimize Apollo Client initialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - [ApolloClient Initialization in React]
+**Learning:** Initializing `ApolloClient` inside a React component (e.g., `App`) causes it to be re-initialized on every render, which destroys the GraphQL cache and triggers unnecessary re-fetches, severely impacting application performance and efficiency.
+**Action:** Always instantiate `ApolloClient` globally (outside of the React component tree) to ensure the cache is preserved across renders and GraphQL caching works as intended.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,17 +15,16 @@ import '../src/styles/app.scss';
 
 import DynamicHeader from './components/DynamicHeader/DynamicHeader';
 
-const clientOracle = () =>
-  new ApolloClient({
-    link: new HttpLink({
-      uri: 'https://api.thegraph.com/subgraphs/name/jdestephen/affogato-sg',
-    }),
-    cache: new InMemoryCache(),
-  });
+// Initialize ApolloClient outside the component to prevent re-initialization and cache destruction on every render.
+const apolloClient = new ApolloClient({
+  link: new HttpLink({
+    uri: 'https://api.thegraph.com/subgraphs/name/jdestephen/affogato-sg',
+  }),
+  cache: new InMemoryCache(),
+});
 
 const App = () => {
   const contracts = useContracts();
-  const apolloClient = clientOracle();
 
   return (
     <>


### PR DESCRIPTION
💡 What: Moved the initialization of `ApolloClient` outside of the `App` component into the module scope.
🎯 Why: Initializing the client inside the React component body caused it to be recreated on every single re-render of `App`, effectively destroying the GraphQL cache and leading to continuous, unnecessary network requests.
📊 Impact: Expected to significantly reduce redundant GraphQL re-fetches and prevent complete cache wipeouts on re-renders, increasing overall app efficiency and frontend responsiveness.
🔬 Measurement: Can be verified by navigating around the dashboard and observing the Network tab. Redundant GraphQL queries that previously fired on re-renders will no longer be triggered, as data will successfully load from the persisted cache.

Added a critical learning in `.jules/bolt.md` reflecting this specific performance pattern.

---
*PR created automatically by Jules for task [7736882579979979944](https://jules.google.com/task/7736882579979979944) started by @AntonioCardenas*