### PR TITLE
⚡ Bolt: Fix ApolloClient cache destruction by preventing re-initialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-28 - Apollo Client Re-initialization Destroys Cache
+**Learning:** Initializing `ApolloClient` inside the React component tree (e.g., inside the `App` component body as `const client = clientOracle()`) destroys the `InMemoryCache` on every re-render. This completely negates the performance benefits of caching GraphQL queries and causes constant, unnecessary network re-fetches across the application.
+**Action:** Always instantiate `ApolloClient` outside of React components at the module scope so that the client and its cache persist across renders.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,17 +15,18 @@ import '../src/styles/app.scss';
 
 import DynamicHeader from './components/DynamicHeader/DynamicHeader';
 
-const clientOracle = () =>
-  new ApolloClient({
-    link: new HttpLink({
-      uri: 'https://api.thegraph.com/subgraphs/name/jdestephen/affogato-sg',
-    }),
-    cache: new InMemoryCache(),
-  });
+// ⚡ Bolt Performance Optimization:
+// Initialize ApolloClient outside the component tree to prevent re-initialization
+// on every render, which destroys the InMemoryCache and causes unnecessary re-fetches.
+const apolloClient = new ApolloClient({
+  link: new HttpLink({
+    uri: 'https://api.thegraph.com/subgraphs/name/jdestephen/affogato-sg',
+  }),
+  cache: new InMemoryCache(),
+});
 
 const App = () => {
   const contracts = useContracts();
-  const apolloClient = clientOracle();
 
   return (
     <>


### PR DESCRIPTION
💡 What: Moved the `ApolloClient` initialization outside of the `App` component into the module scope.

🎯 Why: Initializing `ApolloClient` inside the `App` component body (which was being done via `clientOracle()`) meant that a brand new instance of `ApolloClient` and a new `InMemoryCache` were being created on every single render of the component tree. This effectively destroyed the cache entirely and caused constant, unnecessary network re-fetches for any data query.

📊 Impact: Reduces unnecessary network requests significantly by allowing Apollo's `InMemoryCache` to persist across renders and actually perform its caching duties.

🔬 Measurement: Open the Network tab in browser developer tools. Before this change, multiple repetitive requests to `api.thegraph.com` would be seen navigating around the app. After this change, identical requests should be correctly served from cache, dramatically reducing external network calls.

---
*PR created automatically by Jules for task [3805024470362815198](https://jules.google.com/task/3805024470362815198) started by @AntonioCardenas*