### PR TITLE
🎨 Palette: Add ARIA labels to sidebar toggle button

### DIFF
--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -190,6 +190,8 @@ export default function Home() {
       <button 
         onClick={() => setIsExpanded(!isExpanded)} 
         className="absolute -right-3 top-6 bg-white border border-gray-200 rounded-full p-1 text-gray-500 hover:text-amber-700 hover:shadow-md transition-all z-50 hidden sm:block"
+        aria-label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
+        aria-expanded={isExpanded}
       >
         {isExpanded ? <AiOutlineMenuFold size={20} /> : <AiOutlineMenuUnfold size={20} />}
       </button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` and `aria-expanded` attributes to the icon-only sidebar toggle button (`<button>`) in `src/components/SideBar.tsx`.

### 🎯 Why
Icon-only buttons without accessible names are difficult or impossible for users relying on screen readers to interpret. Adding `aria-label` clearly communicates the button's purpose ("Expand sidebar" or "Collapse sidebar") based on its state, while `aria-expanded` conveys whether the sidebar is currently open or closed. This makes the interface more intuitive and accessible.

### 📸 Before/After
*(No visual changes - strictly an accessibility enhancement for screen readers)*

### ♿ Accessibility
- Added `aria-label` that dynamically updates based on the sidebar's expanded state.
- Added `aria-expanded` attribute to convey state to assistive technologies.

---
*PR created automatically by Jules for task [2021077511876190403](https://jules.google.com/task/2021077511876190403) started by @AntonioCardenas*