### PR TITLE
🧹 Code Health: Clean up commented-out state blocks in FarmsModule

### DIFF
--- a/src/components/Cafepsa/FarmsModule.tsx
+++ b/src/components/Cafepsa/FarmsModule.tsx
@@ -20,12 +20,7 @@ export const FarmsModule = () => {
 
   const { t, i18n } = useTranslation();
   const mrtLocale = ({ es: MRT_Localization_ES, en: MRT_Localization_EN, de: MRT_Localization_DE, fr: MRT_Localization_FR } as Record<string, any>)[i18n.language] ?? MRT_Localization_ES;
-  /*   const [loading, setLoading] = useState(true);
-      const [farmers, setFarmers] = useState<Array<FarmerType>>([]);
-      const [farmersCount, setFarmersCount] = useState(0); */
-  // const [ownerAddress, setOwnerAddress] = useState<string | null>(null);
   const [Data, setData] = useState<any>([]);
-  // const [BlockchainUrl, setBlockchainUrl] = useState<string>('');
 
   const [currentLat, setCurrentLat] = useState('0');
   const [currentLng, setCurrentLng] = useState('0');
@@ -62,10 +57,6 @@ export const FarmsModule = () => {
       window.open(urlStr, '_blank', 'noopener,noreferrer');
     });
   };
-
-  // useEffect(() => {
-
-  // }, []);
 
   const [tableData, setTableData] = useState<any[]>(() => farms);
 


### PR DESCRIPTION
🎯 **What:** Removed commented-out multi-line state declarations (`loading`, `farmers`, `farmersCount`), single-line state declarations (`ownerAddress`, `BlockchainUrl`), and an empty `useEffect` block in `src/components/Cafepsa/FarmsModule.tsx`.
💡 **Why:** These commented-out blocks were dead code cluttering the component's initialization phase and decreasing readability. Removing them improves code maintainability.
✅ **Verification:** Verified by ensuring a successful build without errors using `DISABLE_ESLINT_PLUGIN=true pnpm build` and ran the (empty) test suite with `CI=true pnpm test --passWithNoTests`.
✨ **Result:** A cleaner component initialization phase that is easier to read and maintain.

---
*PR created automatically by Jules for task [6462048052731990943](https://jules.google.com/task/6462048052731990943) started by @AntonioCardenas*