### PR TITLE
⚡ Bolt: Move SDK instantiations outside of React Context provider

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-07-24 - ApolloClient Re-initialization
 **Learning:** Initializing `ApolloClient` inside the main `App` component creates a new instance on every render, destroying the `InMemoryCache` and causing redundant network requests.
 **Action:** Always initialize `ApolloClient` outside of the React component tree to ensure the cache persists and performs efficiently.
+## 2024-05-24 - SDK Instantiation in React Contexts
+**Learning:** SDKs like `Magic` and utilities like `emailjs` were being instantiated inside the `AuthProvider` component, leading to unnecessary re-instantiation on every render of the provider.
+**Action:** Always verify that expensive SDK instantiations and configuration calls (like `new Magic(...)` or `emailjs.init(...)`) are placed outside of React component definitions so they are evaluated only once per module load.

--- a/src/states/AuthContext.tsx
+++ b/src/states/AuthContext.tsx
@@ -32,15 +32,17 @@ const AuthContext = React.createContext<AuthType>({
   authState: null,
 });
 
+// Move Magic and emailjs instantiation outside of component to prevent re-instantiation on every render
+const magicSDK = new Magic(process.env.REACT_APP_MAGIC_API_KEY || "", {
+  network: {
+    rpcUrl: "https://rpc.gnosischain.com/",
+    chainId: 10,
+  },
+});
+emailjs.init(process.env.REACT_APP_EMAILJS_PUBLIC_KEY || "");
+
 export default function AuthProvider({ children }: props) {
   const contracts = useContracts();
-  const magicSDK = new Magic(process.env.REACT_APP_MAGIC_API_KEY || "", {
-    network: {
-      rpcUrl: "https://rpc.gnosischain.com/",
-      chainId: 10,
-    },
-  });
-  emailjs.init(process.env.REACT_APP_EMAILJS_PUBLIC_KEY || "");
 
   const [firebaseData, setFirebaseData] = useState<any>([]);
 


### PR DESCRIPTION
💡 What: Moved the instantiation of `Magic` SDK and the initialization of `emailjs` outside of the `AuthProvider` component in `src/states/AuthContext.tsx`.

🎯 Why: Since `Magic` and `emailjs` were initialized directly inside the `AuthProvider` component's body, they were being needlessly re-instantiated and re-initialized every single time the component re-rendered. This was causing unnecessary overhead and memory allocations.

📊 Impact: Reduces memory usage and CPU cycles by preventing repetitive instantiation of complex SDK objects during every render cycle of the authentication context provider.

🔬 Measurement: Verify by adding a `console.log` alongside the instantiation and observing that it now prints only once per module load, rather than printing on every render of any component that triggers an update in `AuthContext` (or when `AuthProvider` itself updates).

---
*PR created automatically by Jules for task [14814287587785808814](https://jules.google.com/task/14814287587785808814) started by @AntonioCardenas*