### PR TITLE
🎨 Palette: Add accessibility to language chooser

### DIFF
--- a/src/components/common/LangChooser.tsx
+++ b/src/components/common/LangChooser.tsx
@@ -1,19 +1,19 @@
-import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { DE, ES, US, FR } from "country-flag-icons/react/3x2";
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DE, ES, US, FR } from 'country-flag-icons/react/3x2';
 
 type props = {
   type: string;
 };
 
 const FlagComponent = ({ type }: props) => {
-  if (type === "es") {
+  if (type === 'es') {
     return <ES title="Español" className="lang-flag" />;
   }
-  if (type === "de") {
+  if (type === 'de') {
     return <DE title="Deutsch" className="lang-flag" />;
   }
-  if (type === "fr") {
+  if (type === 'fr') {
     return <FR title="Français" className="lang-flag" />;
   }
 
@@ -22,11 +22,13 @@ const FlagComponent = ({ type }: props) => {
 
 const LangChooser = () => {
   const { i18n } = useTranslation();
-  const [currentLang, setCurrentLang] = useState(localStorage.getItem("affogato-lang") || "es");
+  const [currentLang, setCurrentLang] = useState(
+    localStorage.getItem('affogato-lang') || 'es',
+  );
 
   const changeLanguage = (lang: string) => {
     i18n.changeLanguage(lang);
-    localStorage.setItem("affogato-lang", lang);
+    localStorage.setItem('affogato-lang', lang);
     setCurrentLang(lang);
   };
 
@@ -35,30 +37,37 @@ const LangChooser = () => {
     setCurrentLang(eventKey);
   };
 
-
   const LangBar = () => (
     <div className="fixed bottom-4 right-4 z-50 flex items-center bg-white/80 backdrop-blur-md shadow-xl rounded-full p-1 border border-white/40 gap-1">
-      <button 
-        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${currentLang === 'es' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`} 
-        onClick={() => changeLanguage("es")}
+      <button
+        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${currentLang === 'es' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`}
+        onClick={() => changeLanguage('es')}
+        aria-label="Español"
+        aria-current={currentLang === 'es' ? 'true' : undefined}
       >
         <ES title="Español" className="w-6 rounded-sm shadow-sm" />
       </button>
-      <button 
-        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${currentLang === 'en' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`} 
-        onClick={() => changeLanguage("en")}
+      <button
+        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${currentLang === 'en' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`}
+        onClick={() => changeLanguage('en')}
+        aria-label="English"
+        aria-current={currentLang === 'en' ? 'true' : undefined}
       >
         <US title="English" className="w-6 rounded-sm shadow-sm" />
       </button>
-      <button 
-        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${currentLang === 'de' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`} 
-        onClick={() => changeLanguage("de")}
+      <button
+        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${currentLang === 'de' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`}
+        onClick={() => changeLanguage('de')}
+        aria-label="Deutsch"
+        aria-current={currentLang === 'de' ? 'true' : undefined}
       >
         <DE title="Deutsch" className="w-6 rounded-sm shadow-sm" />
       </button>
-      <button 
-        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors ${currentLang === 'fr' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`} 
-        onClick={() => changeLanguage("fr")}
+      <button
+        className={`w-10 h-10 flex items-center justify-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${currentLang === 'fr' ? 'bg-amber-100' : 'hover:bg-gray-100/50'}`}
+        onClick={() => changeLanguage('fr')}
+        aria-label="Français"
+        aria-current={currentLang === 'fr' ? 'true' : undefined}
       >
         <FR title="Français" className="w-6 rounded-sm shadow-sm" />
       </button>


### PR DESCRIPTION
## 💡 What
Added missing `aria-label` and `aria-current` attributes to the icon-only language selection buttons in `LangChooser.tsx`. Also added `focus-visible:ring-2` to ensure clear focus states for keyboard users.

## 🎯 Why
Icon-only buttons are inaccessible to screen readers without proper labels. Users navigating via keyboard also need clear visual indicators of which element currently has focus. `aria-current` helps screen reader users know which language is currently active.

## 📸 Before/After
*(Visual verification was attempted but blocked locally due to missing API keys causing the app to hang in a loading state. Changes were reviewed manually to ensure Tailwind classes match existing conventions.)*

## ♿ Accessibility
- Added `aria-label` for screen reader identification of languages.
- Added `aria-current` to indicate the currently selected language.
- Added visible focus rings (`focus-visible:ring-amber-500`) for keyboard navigation.

---
*PR created automatically by Jules for task [16114061868053374201](https://jules.google.com/task/16114061868053374201) started by @AntonioCardenas*