### PR TITLE
🎨 Palette: Improve form validation with inline feedback

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -42,7 +42,7 @@ const Login = () => {
           credential: areaCode.concat(userInput),
         });
       }
-    } catch (e) { }
+    } catch (e) {}
   };
 
   const handleUserInputChange = (
@@ -99,9 +99,7 @@ const Login = () => {
               <h1 className="mb-3 font-bold text-5xl ">
                 <>{t('welcome')}</>: {t('login.platform-subtitle')}
               </h1>
-              <p className="pr-3 md:text-light">
-                {t('login.slogan')}
-              </p>
+              <p className="pr-3 md:text-light">{t('login.slogan')}</p>
             </div>
           </div>
           <div className="flex justify-center self-center  z-10">
@@ -119,17 +117,39 @@ const Login = () => {
                 onSubmit={() => magicLogin()}
               >
                 <div className="space-y-2">
-                  <label className="text-sm font-medium text-gray-700 tracking-wide">
+                  <label
+                    htmlFor="email-input"
+                    className="text-sm font-medium text-gray-700 tracking-wide"
+                  >
                     {t('email')}:
                   </label>
                   <input
-                    className=" w-full text-base px-4 py-2 border  border-gray-300 rounded-lg focus:border-green-400 focus:ring-2 focus:ring-sky-300 focus:outline-none
-        invalid:ring-2 invalid:ring-red-400"
+                    id="email-input"
+                    className={`w-full text-base px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:outline-none ${
+                      userInput && userInputError
+                        ? 'border-red-500 focus:border-red-500 focus:ring-red-300'
+                        : 'focus:border-green-400 focus:ring-sky-300'
+                    }`}
                     type="email"
                     value={userInput}
                     placeholder={t('placeholders.email') as string}
                     onChange={handleUserInputChange}
+                    aria-invalid={
+                      userInput && userInputError ? 'true' : 'false'
+                    }
+                    aria-describedby={
+                      userInput && userInputError ? 'email-error' : undefined
+                    }
                   />
+                  {userInput && userInputError && (
+                    <p
+                      id="email-error"
+                      className="text-sm text-red-500 mt-1"
+                      role="alert"
+                    >
+                      {userInputError}
+                    </p>
+                  )}
                 </div>
 
                 <div>


### PR DESCRIPTION
💡 What: Added inline validation feedback for the email input field in the Login component. When an invalid email or cellphone is entered, the input border turns red, and an error message is displayed directly below the field.
🎯 Why: Previously, the `userInputError` state was set but never displayed, leaving users confused about why their login attempt might fail if the input format was invalid. This change provides immediate, contextual feedback.
📸 Before/After: Before, no error message was shown, and the input border didn't change color. After, a red border and a helpful error message appear.
♿ Accessibility: Associated the label with the input using `htmlFor` and `id`. Added `aria-invalid` to indicate the error state, `aria-describedby` to associate the error message with the input, and `role="alert"` to ensure screen readers announce the error immediately.

---
*PR created automatically by Jules for task [12198889382588787924](https://jules.google.com/task/12198889382588787924) started by @AntonioCardenas*