### PR TITLE
⚡ Bolt: Memoize BatchItem for List Performance

### DIFF
--- a/src/components/CoffeeBatch/BatchItem.tsx
+++ b/src/components/CoffeeBatch/BatchItem.tsx
@@ -9,7 +9,9 @@ type props = {
     showQrModal: (url: string) => void;
 };
 
-const BatchItem = ({index, coffeeBatch, pagination, showQrModal}: props) => {
+// ⚡ Bolt: wrap with React.memo to prevent unnecessary re-renders when list data or pagination updates,
+// but this specific item hasn't changed.
+const BatchItem = React.memo(({index, coffeeBatch, pagination, showQrModal}: props) => {
     const itemPage = Math.ceil((index + 1) / pagination.itemsPerPage);
     const batchUrl = window.location.origin.concat("/batch/").concat(coffeeBatch.ipfsHash);
 
@@ -70,6 +72,6 @@ const BatchItem = ({index, coffeeBatch, pagination, showQrModal}: props) => {
             </td>
         </tr>
     );
-};
+});
 
 export default BatchItem;

--- a/src/components/CoffeeBatch/List.tsx
+++ b/src/components/CoffeeBatch/List.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { ethers } from "ethers";
 import { Contract } from "ethers";
 import { gql } from "@apollo/client";
@@ -346,9 +346,9 @@ export const List = () => {
     setPagination(newPagination);
   };
 
-  const showQrModal = (url: string) => {
+  const showQrModal = useCallback((url: string) => {
     setQrCodeUrl(url);
-  };
+  }, []);
 
   const handleOnDownloadClick = () => {
     saveSvgAsPng.saveSvgAsPng(


### PR DESCRIPTION
💡 **What**: Wrapped `BatchItem` component in `React.memo()` and stabilized `showQrModal` function in `List.tsx` using `useCallback()`.
🎯 **Why**: When interacting with the coffee batch list (e.g. clicking a QR code to open the modal), the state updates in the parent component `List.tsx` triggered unnecessary re-renders for every single `BatchItem` in the list.
📊 **Impact**: Reduces component re-renders by up to 100% for unaffected `BatchItem` components within the list when the parent's `qrCodeUrl` state changes.
🔬 **Measurement**: Verify by using React DevTools Profiler while clicking the QR code in a long list of batches. Before this change, clicking the QR code would highlight all items as re-rendering. Now, only the parent list should update while the items are skipped.

---
*PR created automatically by Jules for task [15270913511493139550](https://jules.google.com/task/15270913511493139550) started by @AntonioCardenas*