### PR TITLE
⚡ Bolt: Optimize Coffee Batch list rendering by memoizing BatchItem

### DIFF
--- a/src/components/CoffeeBatch/BatchItem.tsx
+++ b/src/components/CoffeeBatch/BatchItem.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import QRCode from "react-qr-code";
 import {CoffeeBatchType, PaginationType} from "../common/types";
 
@@ -72,4 +72,7 @@ const BatchItem = ({index, coffeeBatch, pagination, showQrModal}: props) => {
     );
 };
 
-export default BatchItem;
+// ⚡ Bolt Performance Optimization:
+// Wrap BatchItem with React.memo to prevent unnecessary re-renders of all list items
+// when the parent component updates (e.g., when search inputs or filters change).
+export default memo(BatchItem);

--- a/src/components/CoffeeBatch/List.tsx
+++ b/src/components/CoffeeBatch/List.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { ethers } from "ethers";
 import { Contract } from "ethers";
 import { gql } from "@apollo/client";
@@ -346,9 +346,12 @@ export const List = () => {
     setPagination(newPagination);
   };
 
-  const showQrModal = (url: string) => {
+  // ⚡ Bolt Performance Optimization:
+  // Memoize the callback to prevent invalidating the memoized BatchItem children
+  // on every render of the List component.
+  const showQrModal = useCallback((url: string) => {
     setQrCodeUrl(url);
-  };
+  }, []);
 
   const handleOnDownloadClick = () => {
     saveSvgAsPng.saveSvgAsPng(


### PR DESCRIPTION
💡 **What:** 
Wrapped the `BatchItem` component in `React.memo` and memoized the `showQrModal` callback in `List.tsx` using `useCallback`.

🎯 **Why:** 
Previously, any state change in the parent `List` component (such as opening the QR code modal which updates `qrCodeUrl` state) would cause every single `BatchItem` in the list to re-render. Since lists can contain many items, this caused noticeable rendering overhead. By memoizing the component and its callback prop, we prevent these unnecessary renders.

📊 **Impact:** 
Reduces re-renders of `BatchItem` components by O(N) (where N is the number of visible batches) when performing actions that update parent state, such as opening a QR modal or interacting with search inputs.

🔬 **Measurement:** 
Use the React Profiler to record rendering while clicking a QR code in the coffee batch list. Before the change, all rows re-render. After the change, only the parent component re-renders, while the `BatchItem` components skip rendering.

---
*PR created automatically by Jules for task [16167285758856540106](https://jules.google.com/task/16167285758856540106) started by @AntonioCardenas*