### PR TITLE
🎨 Palette: Improve form input accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## Sidebars & Mobile Navigation
 **Learning:** Sidebars that only hide text but keep the icon track visible on small devices take up too much horizontal space. Users need an explicit way to open/close navigation, and it should act as an overlay to prevent layout shifts.
 **Action:** When implementing responsive sidebars, use an overlay/drawer pattern on mobile screens (<768px) with a dark background to retain context, and ensure that navigating auto-closes the drawer. Ensure toggle buttons are not `hidden` on mobile.
+
+## 2026-08-05 - Programmatic Label-Input Association and Form Validation Accessibility
+**Learning:** When building custom wrapper components around UI library form elements (like React Bootstrap's `Form.Control`), inputs often lack programmatic association with their labels or error messages. This requires manual ID assignment (e.g., via React's `useId()`) to link `htmlFor` on the label with the `id` on the input, and using `aria-invalid`, `aria-describedby`, and `role="alert"` to properly announce validation errors to screen readers.
+**Action:** Always ensure that custom form input wrappers generate and use unique IDs to associate labels with inputs, and apply necessary ARIA attributes to handle error states accessibly.

--- a/src/components/common/FormInput.tsx
+++ b/src/components/common/FormInput.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import Form from "react-bootstrap/Form";
+import React, { useId } from 'react';
+import Form from 'react-bootstrap/Form';
 
 type props = {
   label: string;
@@ -17,20 +17,34 @@ const FormInput = ({
   placeholder,
   handleOnChange,
   handleOnKeyDown,
-  className = "",
-  errorMsg = "",
-}: props) => (
-  <div className="form-input border-0 bg-transparent">
-    <Form.Label>{label}</Form.Label>
-    <Form.Control
-      value={value}
-      placeholder={placeholder}
-      onChange={handleOnChange}
-      onKeyDown={handleOnKeyDown}
-      className={className}
-    />
-    {errorMsg !== "" && <span className="error-message">{errorMsg}</span>}
-  </div>
-);
+  className = '',
+  errorMsg = '',
+}: props) => {
+  const generatedId = useId();
+  const inputId = `form-input-${generatedId}`;
+  const errorId = `form-error-${generatedId}`;
+  const hasError = errorMsg !== '';
+
+  return (
+    <div className="form-input border-0 bg-transparent">
+      <Form.Label htmlFor={inputId}>{label}</Form.Label>
+      <Form.Control
+        id={inputId}
+        value={value}
+        placeholder={placeholder}
+        onChange={handleOnChange}
+        onKeyDown={handleOnKeyDown}
+        className={className}
+        aria-invalid={hasError ? 'true' : 'false'}
+        aria-describedby={hasError ? errorId : undefined}
+      />
+      {hasError && (
+        <span id={errorId} className="error-message" role="alert">
+          {errorMsg}
+        </span>
+      )}
+    </div>
+  );
+};
 
 export default FormInput;


### PR DESCRIPTION
**💡 What**
Improved the `FormInput` component by programmatically associating labels with inputs using React's `useId()` and added necessary ARIA attributes to handle validation error states accessibly. Also recorded a critical learning about wrapping UI library elements safely.

**🎯 Why**
Previously, `FormInput` instances did not explicitly link `Form.Label` to `Form.Control`, making it difficult for screen readers to associate the correct text with the input field. Additionally, validation errors were displayed visually but lacking ARIA associations (`aria-invalid`, `aria-describedby`, and `role="alert"`), so assistive technologies might silently miss error context.

**📸 Before/After**
*Before:* Inputs and labels relied on DOM structure alone. Error messages were plain spans.
*After:* Each instance of `FormInput` generates a unique ID, linking `htmlFor` to `id`. Errors set `aria-invalid="true"`, reference the error `id` in `aria-describedby`, and use `role="alert"`.

**♿ Accessibility**
- Added explicit programmatic label-input association using `useId`.
- Added `aria-invalid` to notify assistive technologies of invalid states.
- Added `aria-describedby` to link the input directly to the error message.
- Added `role="alert"` to the error message so it is announced immediately when it appears.

---
*PR created automatically by Jules for task [10791220984263754587](https://jules.google.com/task/10791220984263754587) started by @AntonioCardenas*