### PR TITLE
⚡ Bolt: [Performance Improvement] Prevent rendering hidden QRCodes and add React.memo in BatchItem

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,6 @@
 **Learning:** SDKs like `Magic` and utilities like `emailjs` were being instantiated inside the `AuthProvider` component, leading to unnecessary re-instantiation on every render of the provider.
 **Action:** Always verify that expensive SDK instantiations and configuration calls (like `new Magic(...)` or `emailjs.init(...)`) are placed outside of React component definitions so they are evaluated only once per module load.
 
+## 2025-03-05 - Optimizing Paginated Tables with DOM-dependent Export Tools
+**Learning:** When using DOM-based export tools (like `ReactHTMLTableToExcel`), you cannot simply remove hidden paginated rows from the DOM because the export tool requires them to be physically present.
+**Action:** Instead of unmounting hidden rows, use CSS to hide them (`display: none`) and apply `React.memo` to the row component with a custom comparison function. Conditionally render heavy child components (like `<QRCode>`) based on the row's visibility prop. This prevents React from needlessly re-rendering and building heavy elements for hidden rows while keeping the lightweight DOM structure intact for the export tool.

--- a/src/components/CoffeeBatch/BatchItem.tsx
+++ b/src/components/CoffeeBatch/BatchItem.tsx
@@ -11,6 +11,7 @@ type props = {
 
 const BatchItem = ({index, coffeeBatch, pagination, showQrModal}: props) => {
     const itemPage = Math.ceil((index + 1) / pagination.itemsPerPage);
+    const isVisible = pagination.current === itemPage;
     const batchUrl = window.location.origin.concat("/batch/").concat(coffeeBatch.ipfsHash);
 
     const openInNewTab = (url: string | URL | undefined) => {
@@ -20,7 +21,7 @@ const BatchItem = ({index, coffeeBatch, pagination, showQrModal}: props) => {
     return (
         <tr
             key={coffeeBatch.id}
-            className={`${pagination.current === itemPage ? "show" : "hide"} flex flex-col flex-no wrap sm:table-row mb-2 sm:mb-0 border-grey-light border-2`}
+            className={`${isVisible ? "show" : "hide"} flex flex-col flex-no wrap sm:table-row mb-2 sm:mb-0 border-grey-light border-2`}
         >
             <td className="p-3 text-base font-light">
                 <div className="qrcode">
@@ -29,7 +30,7 @@ const BatchItem = ({index, coffeeBatch, pagination, showQrModal}: props) => {
                                showQrModal(batchUrl);
                            }}
                     >
-                        <QRCode value={batchUrl} size={90} />
+                        {isVisible && <QRCode value={batchUrl} size={90} />}
                     </label>
                 </div>
             </td>
@@ -72,4 +73,22 @@ const BatchItem = ({index, coffeeBatch, pagination, showQrModal}: props) => {
     );
 };
 
-export default BatchItem;
+// ⚡ Bolt Performance Optimization:
+// Use React.memo with a custom comparison to prevent re-rendering hidden rows.
+// By conditionally rendering the heavy <QRCode> only when visible, we drastically
+// improve rendering performance for large lists while keeping the hidden DOM
+// rows present for the ReactHTMLTableToExcel export tool.
+export default React.memo(BatchItem, (prevProps, nextProps) => {
+    if (prevProps.coffeeBatch !== nextProps.coffeeBatch) return false;
+    if (prevProps.index !== nextProps.index) return false;
+    if (prevProps.showQrModal !== nextProps.showQrModal) return false;
+
+    const prevItemPage = Math.ceil((prevProps.index + 1) / prevProps.pagination.itemsPerPage);
+    const prevIsVisible = prevProps.pagination.current === prevItemPage;
+
+    const nextItemPage = Math.ceil((nextProps.index + 1) / nextProps.pagination.itemsPerPage);
+    const nextIsVisible = nextProps.pagination.current === nextItemPage;
+
+    // Only re-render if the item's visibility status has changed
+    return prevIsVisible === nextIsVisible;
+});


### PR DESCRIPTION
💡 **What**: Added `React.memo` with a custom comparison function to `BatchItem.tsx` and conditionally rendered the heavy `<QRCode>` component only when the row is actually visible in the current pagination view. Added a journal entry to `.jules/bolt.md` documenting the limitation around DOM-based exports requiring hidden nodes.

🎯 **Why**: When paging through a large table of items, React was unnecessarily re-rendering hidden components. Additionally, building the `<QRCode>` canvas element takes a noticeable amount of time per row. We cannot simply conditionally render the entire `<tr>` row when hidden because the `ReactHTMLTableToExcel` plugin relies on these hidden nodes being present in the DOM. By using `React.memo` with a custom compare and lazily rendering just the heavy child elements like `<QRCode>`, we fix the performance bottleneck without breaking the export functionality.

📊 **Impact**: This significantly improves rendering performance when paging through `List.tsx`. The amount of DOM manipulation required when changing pages goes from building 10+ new `<canvas>` elements to simply toggling visibility state for the previously rendered components.

🔬 **Measurement**: Navigate to the CoffeeBatch List screen. Change pages using the pagination component. The UI transition should be noticeably faster without lag since we no longer trigger full re-renders for every single row item when the page changes. Verify the Excel export still works as expected.

---
*PR created automatically by Jules for task [12515036069590500619](https://jules.google.com/task/12515036069590500619) started by @AntonioCardenas*