### PR TITLE
🎨 Palette: Improve FormInput accessibility with linked labels and ARIA

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## Sidebars & Mobile Navigation
 **Learning:** Sidebars that only hide text but keep the icon track visible on small devices take up too much horizontal space. Users need an explicit way to open/close navigation, and it should act as an overlay to prevent layout shifts.
 **Action:** When implementing responsive sidebars, use an overlay/drawer pattern on mobile screens (<768px) with a dark background to retain context, and ensure that navigating auto-closes the drawer. Ensure toggle buttons are not `hidden` on mobile.
+## 2024-05-18 - Linking React Bootstrap Form Controls
+**Learning:** When creating reusable form components using React Bootstrap, `<Form.Label>` does not automatically associate with `<Form.Control>` if they are siblings without explicit IDs. Screen readers fail to announce the label when the input receives focus. Furthermore, dynamic validation error messages need to be explicitly tied to the input using `aria-describedby` to be announced properly.
+**Action:** Always generate a unique ID using React's `useId()` hook to explicitly link `<Form.Label htmlFor={id}>` to `<Form.Control id={id}>`. For validation errors, use `aria-invalid` on the input, and use `aria-describedby` linking to the error message container which should have `role="alert"`. This ensures the structure is natively accessible and robust for assistive technologies.

--- a/src/components/common/FormInput.tsx
+++ b/src/components/common/FormInput.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import Form from "react-bootstrap/Form";
+import React, { useId } from 'react';
+import Form from 'react-bootstrap/Form';
 
 type props = {
   label: string;
@@ -17,20 +17,33 @@ const FormInput = ({
   placeholder,
   handleOnChange,
   handleOnKeyDown,
-  className = "",
-  errorMsg = "",
-}: props) => (
-  <div className="form-input border-0 bg-transparent">
-    <Form.Label>{label}</Form.Label>
-    <Form.Control
-      value={value}
-      placeholder={placeholder}
-      onChange={handleOnChange}
-      onKeyDown={handleOnKeyDown}
-      className={className}
-    />
-    {errorMsg !== "" && <span className="error-message">{errorMsg}</span>}
-  </div>
-);
+  className = '',
+  errorMsg = '',
+}: props) => {
+  const inputId = useId();
+  const errorId = `${inputId}-error`;
+  const isInvalid = errorMsg !== '';
+
+  return (
+    <div className="form-input border-0 bg-transparent">
+      <Form.Label htmlFor={inputId}>{label}</Form.Label>
+      <Form.Control
+        id={inputId}
+        value={value}
+        placeholder={placeholder}
+        onChange={handleOnChange}
+        onKeyDown={handleOnKeyDown}
+        className={className}
+        aria-invalid={isInvalid ? 'true' : 'false'}
+        aria-describedby={isInvalid ? errorId : undefined}
+      />
+      {isInvalid && (
+        <span id={errorId} className="error-message" role="alert">
+          {errorMsg}
+        </span>
+      )}
+    </div>
+  );
+};
 
 export default FormInput;


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the reusable `FormInput` component by using React's `useId()` to dynamically generate and link unique IDs for the input and its corresponding validation error.

🎯 **Why:** To ensure screen readers can reliably associate the visual label with the input field and properly announce dynamic validation error messages as they occur.

📸 **Before/After:**
*Before:* `Form.Label` was structurally unlinked from `Form.Control`. Validation errors lacked ARIA attributes.
*After:* `Form.Label` correctly uses `htmlFor` matching `Form.Control`'s `id`. Errors utilize `aria-invalid`, `aria-describedby`, and `role="alert"`.

♿ **Accessibility:**
- Links label and input explicitly using `useId()`.
- Utilizes `aria-invalid` to indicate error state.
- Employs `aria-describedby` to associate the input with its specific error text.
- Sets `role="alert"` on the error message for immediate screen reader announcement.

---
*PR created automatically by Jules for task [6480615635829562105](https://jules.google.com/task/6480615635829562105) started by @AntonioCardenas*