### PR TITLE
🎨 Palette: Improve pagination accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## Sidebars & Mobile Navigation
 **Learning:** Sidebars that only hide text but keep the icon track visible on small devices take up too much horizontal space. Users need an explicit way to open/close navigation, and it should act as an overlay to prevent layout shifts.
 **Action:** When implementing responsive sidebars, use an overlay/drawer pattern on mobile screens (<768px) with a dark background to retain context, and ensure that navigating auto-closes the drawer. Ensure toggle buttons are not `hidden` on mobile.
+
+## 2026-08-11 - Pagination Accessibility Patterns
+**Learning:** Pagination components often rely on visual cues (like an active class for the current page, or "..." for truncation) and symbols (like "«" and "»") that are unhelpful or confusing to screen readers. For instance, "«" might be read aloud literally as "left pointing double angle quotation mark".
+**Action:** Use `aria-current="page"` to explicitly denote the active page. Hide decorative elements like "..." from assistive tech using `aria-hidden="true"` and `tabIndex={-1}`. Use `aria-label` and `title` on symbol buttons (e.g., "First page") to provide clear semantic meaning.

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,136 +1,184 @@
-import React from "react";
-import {PaginationType} from "./types";
-import {useTranslation} from "react-i18next";
+import React from 'react';
+import { PaginationType } from './types';
+import { useTranslation } from 'react-i18next';
 
 type props = {
-    pagination: PaginationType;
-    onPageSelected: (pageNumber: number) => void;
-    className: string;
+  pagination: PaginationType;
+  onPageSelected: (pageNumber: number) => void;
+  className: string;
 };
 
-export const CustomPagination = ({pagination, onPageSelected, className}: props) => {
-    const {t} = useTranslation();
-    const pag = Array.from(Array(pagination.pages).keys());
-    const activePag = pagination.current;
+export const CustomPagination = ({
+  pagination,
+  onPageSelected,
+  className,
+}: props) => {
+  const { t } = useTranslation();
+  const pag = Array.from(Array(pagination.pages).keys());
+  const activePag = pagination.current;
 
-    const VaultPages = () => {
-        const midPages = Array.from(Array(5).keys());
-        const midPage = Math.floor(pagination.pages / 2);
-        midPages[0] = midPage - 2;
-        midPages[1] = midPage - 1;
-        midPages[2] = midPage;
-        midPages[3] = midPage + 1;
-        midPages[4] = midPage + 2;
-
-        return (
-            <div className="btn-group">
-                <button
-                    onClick={() => onPageSelected(1)}
-                    className={`${pagination.current === 1 && "btn-active"} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
-                >{1}</button>
-                {pagination.current >= 3 && pagination.current < midPages[0] && (
-                    <button className="btn btn-disabled border border-black btn-xs sm:btn-sm md:btn-md lg:btn-md">...</button>
-                )}
-                {pagination.current > 1 && pagination.current < midPages[0] && (
-                    <button
-                        onClick={() => onPageSelected(pagination.current)}
-                        className={`${pagination.current === activePag && "btn-active"} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
-                    >{activePag}</button>
-                )}
-                <button className="btn btn-disabled border border-black btn-xs sm:btn-sm md:btn-md lg:btn-md">...</button>
-
-                {midPages.map((item) => (
-                    <button
-                        key={item}
-                        onClick={() => onPageSelected(item)}
-                        className={`${pagination.current === item && "btn-active"} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
-                    >
-                        {item}
-                    </button>
-                ))}
-                <button className="btn btn-disabled border border-black btn-xs sm:btn-sm md:btn-md lg:btn-md">...</button>
-
-                {pagination.current < pagination.pages &&
-                    pagination.current > midPages[4] && (
-                        <button
-                            className={`${pagination.current === pagination.pages && "btn-active"} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
-                        >{activePag}</button>
-                    )}
-                {pagination.current < pagination.pages - 1 &&
-                    pagination.current > midPages[4] &&
-                    <button className="btn btn-disabled border border-black btn-xs sm:btn-sm md:btn-md lg:btn-md">...</button>
-                }
-                <button
-                    onClick={() => onPageSelected(pagination.pages)}
-                    className={`${pagination.current === pagination.pages && "btn-active"} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
-                >
-                    {pagination.pages}
-                </button>
-            </div>
-        );
-    };
+  const VaultPages = () => {
+    const midPages = Array.from(Array(5).keys());
+    const midPage = Math.floor(pagination.pages / 2);
+    midPages[0] = midPage - 2;
+    midPages[1] = midPage - 1;
+    midPages[2] = midPage;
+    midPages[3] = midPage + 1;
+    midPages[4] = midPage + 2;
 
     return (
-        <div
+      <div className="btn-group">
+        <button
+          onClick={() => onPageSelected(1)}
+          className={`${pagination.current === 1 && 'btn-active'} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
+          aria-current={pagination.current === 1 ? 'page' : undefined}
+        >
+          {1}
+        </button>
+        {pagination.current >= 3 && pagination.current < midPages[0] && (
+          <button
+            aria-hidden="true"
+            tabIndex={-1}
+            className="btn btn-disabled border border-black btn-xs sm:btn-sm md:btn-md lg:btn-md"
+          >
+            ...
+          </button>
+        )}
+        {pagination.current > 1 && pagination.current < midPages[0] && (
+          <button
+            onClick={() => onPageSelected(pagination.current)}
+            className={`${pagination.current === activePag && 'btn-active'} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
+            aria-current={pagination.current === activePag ? 'page' : undefined}
+          >
+            {activePag}
+          </button>
+        )}
+        <button
+          aria-hidden="true"
+          tabIndex={-1}
+          className="btn btn-disabled border border-black btn-xs sm:btn-sm md:btn-md lg:btn-md"
+        >
+          ...
+        </button>
 
-            // @ts-ignore
+        {midPages.map((item) => (
+          <button
+            key={item}
+            onClick={() => onPageSelected(item)}
+            className={`${pagination.current === item && 'btn-active'} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
+            aria-current={pagination.current === item ? 'page' : undefined}
+          >
+            {item}
+          </button>
+        ))}
+        <button
+          aria-hidden="true"
+          tabIndex={-1}
+          className="btn btn-disabled border border-black btn-xs sm:btn-sm md:btn-md lg:btn-md"
+        >
+          ...
+        </button>
 
-        className={`btn-group ${className} lg:btn-group-horizontal w-fit overflow-hidden pt-4`}>
-            {pagination.pages >= 10 && (
-                <button
-                    onClick={() => onPageSelected(1)}
-                    disabled={pagination.previous === 0}
-
-                    className="btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md">
-                    «
-                </button>
-            )}
-            {pagination.pages > 1 && (
-                <button
-                    onClick={() => onPageSelected(pagination.previous)}
-                    disabled={pagination.previous === 0}
-                    className="btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md"
-                ><>{t("previous")}</>
-                </button>
-            )}
-
-
-            {pagination.pages >= 10 ? (
-                <VaultPages/>
-            ) : (
-                pag.map((item) => (
-                    <button
-                        id={"button" + `${item}`}
-                        key={item}
-                        onClick={() => onPageSelected(item)}
-                        className={`${pagination.current === item && "btn-active"} custom-pagination  btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
-                    >
-                        {item}
-                    </button>
-                ))
-            )}
-
-            {pagination.pages > 1 && (
-
-
-                <button
-                onClick={() => onPageSelected(pagination.next)}
-                disabled={pagination.current === pagination.pages}
-                className="btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md"
+        {pagination.current < pagination.pages &&
+          pagination.current > midPages[4] && (
+            <button
+              className={`${pagination.current === pagination.pages && 'btn-active'} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
+              aria-current={
+                pagination.current === pagination.pages ? 'page' : undefined
+              }
             >
-                <>{t("next")}</>
+              {activePag}
             </button>
-            )}
-
-
-            {pagination.pages >= 10 && (
-                <button
-                    onClick={() => onPageSelected(pagination.pages)}
-                    disabled={pagination.next === 0}
-                    className="btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md"
-                >»
-                </button>
-            )}
-        </div>
+          )}
+        {pagination.current < pagination.pages - 1 &&
+          pagination.current > midPages[4] && (
+            <button
+              aria-hidden="true"
+              tabIndex={-1}
+              className="btn btn-disabled border border-black btn-xs sm:btn-sm md:btn-md lg:btn-md"
+            >
+              ...
+            </button>
+          )}
+        <button
+          onClick={() => onPageSelected(pagination.pages)}
+          className={`${pagination.current === pagination.pages && 'btn-active'} btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
+          aria-current={
+            pagination.current === pagination.pages ? 'page' : undefined
+          }
+        >
+          {pagination.pages}
+        </button>
+      </div>
     );
+  };
+
+  return (
+    <div
+      // @ts-ignore
+
+      className={`btn-group ${className} lg:btn-group-horizontal w-fit overflow-hidden pt-4`}
+    >
+      {pagination.pages >= 10 && (
+        <button
+          onClick={() => onPageSelected(1)}
+          disabled={pagination.previous === 0}
+          aria-label="First page"
+          title="First page"
+          className="btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md"
+        >
+          «
+        </button>
+      )}
+      {pagination.pages > 1 && (
+        <button
+          onClick={() => onPageSelected(pagination.previous)}
+          disabled={pagination.previous === 0}
+          aria-label={(t('previous') as string) || 'Previous page'}
+          className="btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md"
+        >
+          <>{t('previous')}</>
+        </button>
+      )}
+
+      {pagination.pages >= 10 ? (
+        <VaultPages />
+      ) : (
+        pag.map((item) => (
+          <button
+            id={'button' + `${item}`}
+            key={item}
+            onClick={() => onPageSelected(item)}
+            className={`${pagination.current === item && 'btn-active'} custom-pagination  btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md`}
+            aria-current={pagination.current === item ? 'page' : undefined}
+          >
+            {item}
+          </button>
+        ))
+      )}
+
+      {pagination.pages > 1 && (
+        <button
+          onClick={() => onPageSelected(pagination.next)}
+          disabled={pagination.current === pagination.pages}
+          aria-label={(t('next') as string) || 'Next page'}
+          className="btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md"
+        >
+          <>{t('next')}</>
+        </button>
+      )}
+
+      {pagination.pages >= 10 && (
+        <button
+          onClick={() => onPageSelected(pagination.pages)}
+          disabled={pagination.next === 0}
+          aria-label="Last page"
+          title="Last page"
+          className="btn btn-outline btn-xs sm:btn-sm md:btn-md lg:btn-md"
+        >
+          »
+        </button>
+      )}
+    </div>
+  );
 };


### PR DESCRIPTION
💡 **What**: Improved screen reader and keyboard accessibility for the CustomPagination component by providing context and explicitly managing hidden/active states.
🎯 **Why**: Previously, the visual pagination states (like the active current page or decorative ellipsis `...`) were completely opaque to screen readers, and the navigation arrows (`«`, `»`) lacked descriptive aria labels (screen readers might read "left pointing double angle quotation mark"). 
📸 **Before/After**: Screen readers will now announce "First page" instead of "left pointing double angle quotation mark" and properly understand which page is currently selected. Decorative ellipsis are skipped from focus.
♿ **Accessibility**:
- Added `aria-current="page"` to the active page number
- Added `aria-hidden="true"` and `tabIndex={-1}` to the decorative `...` separator buttons
- Added `aria-label`s to the `«` (First page) and `»` (Last page) navigation buttons
- Added robust fallback `aria-label`s to the previous/next buttons.

---
*PR created automatically by Jules for task [934526976418630810](https://jules.google.com/task/934526976418630810) started by @AntonioCardenas*