### PR TITLE
🎨 Palette: Improve Signup a11y

### DIFF
--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -725,8 +725,20 @@ const Signup = () => {
               <div className="flex avatar w-24 bg-red-500  mx-auto">
                 <img
                   src={selectedImage !== '' ? selectedImage : User}
-                  className="rounded-xl"
+                  className="rounded-xl cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
                   onClick={handleClick}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      handleClick(e);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  alt={
+                    t('signup.profile-picture-upload') ||
+                    'Upload profile picture'
+                  }
                 />
                 <Form.Control
                   type="file"
@@ -926,24 +938,30 @@ const Signup = () => {
             {!state.accountCreated ? (
               <div className="">
                 <div className="bg-base-100 pt-4 rounded-t-xl m-12 lg:mx-64">
-                  <div className="flex tabs justify-center">
-                    <a
-                      className={`${activeTab == 'farmer' && `tab btn-wide tab-lg  tab-lifted tab-active`} tab btn-wide tab-lg `}
-                      id="signup-tabs"
+                  <div className="flex tabs justify-center" role="tablist">
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={activeTab === 'farmer'}
+                      className={`${activeTab === 'farmer' ? `tab btn-wide tab-lg tab-lifted tab-active` : `tab btn-wide tab-lg`} focus-visible:ring-2 focus-visible:outline-none`}
+                      id="signup-tab-farmer"
                       onClick={() => setActiveTab('farmer')}
                     >
                       <>{t('farmer')}</>
-                    </a>
-                    <a
-                      className={`${activeTab == 'cooperative' && `tab btn-wide tab-lg tab-lifted tab-active`} tab btn-wide tab-lg `}
-                      id="signup-tabs"
+                    </button>
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={activeTab === 'cooperative'}
+                      className={`${activeTab === 'cooperative' ? `tab btn-wide tab-lg tab-lifted tab-active` : `tab btn-wide tab-lg`} focus-visible:ring-2 focus-visible:outline-none`}
+                      id="signup-tab-cooperative"
                       onClick={() => setActiveTab('cooperative')}
                     >
                       <>{t('company')}</>
-                    </a>
+                    </button>
                   </div>
 
-                  {activeTab == 'farmer' && <div>{RenderFarmerForm()}</div>}
+                  {activeTab === 'farmer' && <div>{RenderFarmerForm()}</div>}
 
                   {activeTab == 'cooperative' && <div>{RenderForm()}</div>}
                 </div>


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the Signup tabs and interactive profile picture uploader. Replaced non-semantic `<a>` tags with `<button role="tab">` and added necessary ARIA and keyboard interaction props to the profile `<img>` element.

🎯 Why: To improve the user experience for those relying on keyboard navigation and screen readers, ensuring that all interactive elements on the Signup form are fully accessible.

📸 Before/After: Visuals remain the same, but interactive elements now have visible focus rings (`focus-visible`) and proper semantic markup.

♿ Accessibility:
- Swapped non-functional `<a>` elements for `<button type="button" role="tab">` in the role selector tablist, adding `aria-selected` tracking.
- Made the profile image uploader keyboard accessible by adding `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler to trigger the file input via 'Enter' or 'Space'.
- Ensured strong focus-visible styles across updated components.

---
*PR created automatically by Jules for task [9048260724401649971](https://jules.google.com/task/9048260724401649971) started by @AntonioCardenas*