### PR TITLE
🎨 Palette: Enhance keyboard accessibility for interactive elements in Signup

### DIFF
--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -725,8 +725,17 @@ const Signup = () => {
               <div className="flex avatar w-24 bg-red-500  mx-auto">
                 <img
                   src={selectedImage !== '' ? selectedImage : User}
-                  className="rounded-xl"
+                  className="rounded-xl cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   onClick={handleClick}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      handleClick(e);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={(t('upload-image') as string) || 'Upload image'}
                 />
                 <Form.Control
                   type="file"
@@ -926,18 +935,36 @@ const Signup = () => {
             {!state.accountCreated ? (
               <div className="">
                 <div className="bg-base-100 pt-4 rounded-t-xl m-12 lg:mx-64">
-                  <div className="flex tabs justify-center">
+                  <div className="flex tabs justify-center" role="tablist">
                     <a
-                      className={`${activeTab == 'farmer' && `tab btn-wide tab-lg  tab-lifted tab-active`} tab btn-wide tab-lg `}
-                      id="signup-tabs"
+                      className={`${activeTab == 'farmer' && `tab btn-wide tab-lg  tab-lifted tab-active`} tab btn-wide tab-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`}
+                      id="signup-tabs-farmer"
                       onClick={() => setActiveTab('farmer')}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setActiveTab('farmer');
+                        }
+                      }}
+                      role="tab"
+                      aria-selected={activeTab === 'farmer'}
+                      tabIndex={0}
                     >
                       <>{t('farmer')}</>
                     </a>
                     <a
-                      className={`${activeTab == 'cooperative' && `tab btn-wide tab-lg tab-lifted tab-active`} tab btn-wide tab-lg `}
-                      id="signup-tabs"
+                      className={`${activeTab == 'cooperative' && `tab btn-wide tab-lg tab-lifted tab-active`} tab btn-wide tab-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`}
+                      id="signup-tabs-company"
                       onClick={() => setActiveTab('cooperative')}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setActiveTab('cooperative');
+                        }
+                      }}
+                      role="tab"
+                      aria-selected={activeTab === 'cooperative'}
+                      tabIndex={0}
                     >
                       <>{t('company')}</>
                     </a>


### PR DESCRIPTION
### 💡 What
Added keyboard accessibility, ARIA roles, and visible focus states to the avatar image upload trigger and the Farmer/Company tabs in the Signup flow. Also fixed an HTML issue where both tabs shared the same `id`.

### 🎯 Why
Previously, the avatar image upload and the signup tabs were only interactive via mouse clicks (`onClick`). Keyboard and screen reader users had no way of knowing these elements were interactive or navigating to them. This change ensures everyone can use the signup flow regardless of input device.

### 📸 Before/After
**Before:**
- Avatar upload `<img onClick>` was skipped by keyboard navigation.
- Tabs `<a>` had `onClick` but no `href`, making them un-focusable. Screen readers announced them as text, not tabs.
- No visual feedback when navigating via keyboard.

**After:**
- Both elements can receive focus (`tabIndex={0}`) and be activated via Enter or Space.
- Keyboard users see a clear blue focus ring (`focus-visible:ring-2 focus-visible:ring-blue-500`).
- Screen readers announce the elements correctly as "Upload image button" and "tab".

### ♿ Accessibility
- Added `role="button"` and `aria-label` to the avatar upload.
- Added `role="tablist"` to the tabs container.
- Added `role="tab"` and dynamic `aria-selected` to the individual tabs.
- Ensured focus indicators are only shown for keyboard users using Tailwind's `focus-visible`.

---
*PR created automatically by Jules for task [13411818023269512067](https://jules.google.com/task/13411818023269512067) started by @AntonioCardenas*