### PR TITLE
🎨 Palette: Add keyboard support to signup tabs

### DIFF
--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -928,16 +928,32 @@ const Signup = () => {
                 <div className="bg-base-100 pt-4 rounded-t-xl m-12 lg:mx-64">
                   <div className="flex tabs justify-center">
                     <a
-                      className={`${activeTab == 'farmer' && `tab btn-wide tab-lg  tab-lifted tab-active`} tab btn-wide tab-lg `}
+                      className={`${activeTab == 'farmer' && `tab btn-wide tab-lg  tab-lifted tab-active`} tab btn-wide tab-lg focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-amber-500`}
                       id="signup-tabs"
+                      role="tab"
+                      tabIndex={0}
                       onClick={() => setActiveTab('farmer')}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setActiveTab('farmer');
+                        }
+                      }}
                     >
                       <>{t('farmer')}</>
                     </a>
                     <a
-                      className={`${activeTab == 'cooperative' && `tab btn-wide tab-lg tab-lifted tab-active`} tab btn-wide tab-lg `}
+                      className={`${activeTab == 'cooperative' && `tab btn-wide tab-lg tab-lifted tab-active`} tab btn-wide tab-lg focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-amber-500`}
                       id="signup-tabs"
+                      role="tab"
+                      tabIndex={0}
                       onClick={() => setActiveTab('cooperative')}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setActiveTab('cooperative');
+                        }
+                      }}
                     >
                       <>{t('company')}</>
                     </a>


### PR DESCRIPTION
**💡 What**
Added keyboard navigation support to the "farmer" and "company" tabs on the Signup page.

**🎯 Why**
The tabs were implemented using `<a>` tags and `onClick` handlers but lacked keyboard accessibility. This change allows users navigating with a keyboard to switch between the tabs using the 'Tab' key to focus and the 'Enter' or 'Space' keys to select.

**📸 Before/After**
* Before: Tabs could only be interacted with via mouse clicks. Keyboard users could not access or switch between the forms.
* After: Tabs are focusable, display a clear focus ring (`focus-visible:ring-amber-500`), and can be activated via standard keyboard interactions.

**♿ Accessibility**
- Added `role="tab"` to communicate the element's purpose to screen readers.
- Added `tabIndex={0}` to make the tabs focusable in the document flow.
- Added `onKeyDown` event listeners to trigger tab switching via 'Enter' or 'Space'.
- Added Tailwind `focus-visible` utilities (`focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-amber-500`) to provide a clear, accessible visual indicator when focused via keyboard without affecting mouse interactions.

---
*PR created automatically by Jules for task [7563503245364248920](https://jules.google.com/task/7563503245364248920) started by @AntonioCardenas*