### PR TITLE
🎨 Palette: Enhance keyboard accessibility for signup tabs

### DIFF
--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -926,18 +926,34 @@ const Signup = () => {
             {!state.accountCreated ? (
               <div className="">
                 <div className="bg-base-100 pt-4 rounded-t-xl m-12 lg:mx-64">
-                  <div className="flex tabs justify-center">
+                  <div className="flex tabs justify-center" role="tablist">
                     <a
-                      className={`${activeTab == 'farmer' && `tab btn-wide tab-lg  tab-lifted tab-active`} tab btn-wide tab-lg `}
-                      id="signup-tabs"
+                      className={`${activeTab == 'farmer' && `tab btn-wide tab-lg  tab-lifted tab-active`} tab btn-wide tab-lg focus-visible:ring-2 focus-visible:outline-none cursor-pointer`}
+                      role="tab"
+                      tabIndex={0}
+                      aria-selected={activeTab === 'farmer'}
                       onClick={() => setActiveTab('farmer')}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setActiveTab('farmer');
+                        }
+                      }}
                     >
                       <>{t('farmer')}</>
                     </a>
                     <a
-                      className={`${activeTab == 'cooperative' && `tab btn-wide tab-lg tab-lifted tab-active`} tab btn-wide tab-lg `}
-                      id="signup-tabs"
+                      className={`${activeTab == 'cooperative' && `tab btn-wide tab-lg tab-lifted tab-active`} tab btn-wide tab-lg focus-visible:ring-2 focus-visible:outline-none cursor-pointer`}
+                      role="tab"
+                      tabIndex={0}
+                      aria-selected={activeTab === 'cooperative'}
                       onClick={() => setActiveTab('cooperative')}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setActiveTab('cooperative');
+                        }
+                      }}
                     >
                       <>{t('company')}</>
                     </a>


### PR DESCRIPTION
**💡 What**
Added keyboard navigation support (Enter and Space keys), focus-visible styling (Tailwind ring), `tabIndex={0}`, and correct ARIA roles (`tab`, `tablist`, `aria-selected`) to the custom anchor (`<a>`) tabs used on the Signup page. Also removed a duplicated HTML `id`.

**🎯 Why**
The custom tabs on the Signup page were implemented using `<a>` tags without `href` attributes, making them unreachable via the `Tab` key and un-activatable via the keyboard for users who depend on keyboard navigation. They also lacked semantic roles, meaning screen readers would not announce them correctly as a tab group. 

**📸 Before/After**
*   **Before:** Users tabbing through the page would skip over the tabs completely. Screen readers announced them vaguely as links or plain text.
*   **After:** Users can `Tab` into the tab list, see a clear focus indicator, switch tabs using `Enter` or `Space`, and hear proper semantic announcements via screen readers.

**♿ Accessibility**
*   Added `role="tablist"` to the container.
*   Added `role="tab"` and `tabIndex={0}` to the tabs.
*   Added `aria-selected` to reflect the active tab state.
*   Added `onKeyDown` handlers for Enter/Space selection.
*   Added `focus-visible:ring-2 focus-visible:outline-none` for visible focus indicators.
*   Removed the duplicate `id="signup-tabs"`.

---
*PR created automatically by Jules for task [2039563502103872716](https://jules.google.com/task/2039563502103872716) started by @AntonioCardenas*